### PR TITLE
Fix parseTextResponse difficulty field

### DIFF
--- a/src/utils/aiService.ts
+++ b/src/utils/aiService.ts
@@ -125,8 +125,7 @@ export class AITaskBreakdownService {
           title: title.trim(),
           duration: '10 mins',
           description: rest.join(':').trim() || title.trim(),
-          type: 'work',
-          difficulty: 'medium'
+          type: 'work'
         });
       }
     }


### PR DESCRIPTION
## Summary
- remove `difficulty` from parseTextResponse

## Testing
- `npx tsc -p tsconfig.app.json` *(fails: React and other unused variables, missing Task fields, etc.)*