### PR TITLE
Fix energyRequired default in text fallback

### DIFF
--- a/src/utils/aiService.ts
+++ b/src/utils/aiService.ts
@@ -126,7 +126,7 @@ export class AITaskBreakdownService {
           duration: '10 mins',
           description: rest.join(':').trim() || title.trim(),
           type: 'work',
-          difficulty: 'medium'
+          energyRequired: 'medium'
         });
       }
     }


### PR DESCRIPTION
## Summary
- set default `energyRequired` when parsing text responses in `aiService`

## Testing
- `npx tsc -p tsconfig.app.json` *(fails: missing Task properties and other errors)*