### PR TITLE
Fix AI breakdown subtasks naming

### DIFF
--- a/src/pages/TasksPageWithBulkOps.tsx
+++ b/src/pages/TasksPageWithBulkOps.tsx
@@ -179,21 +179,17 @@ const TasksPageWithBulkOps: React.FC = () => {
       console.log('Subtasks received:', subtasks);
 
       // Prepare all subtasks with parentTaskId and other inherited fields
-      const preparedSubtasks = subtasks.map((subtask) => {
-        // Remove id if present, so the backend/context can generate it
-        const { id, ...rest } = subtask;
-        return {
-          ...rest,
-          parentTaskId: breakdownTask.id,
-          projectId: breakdownTask.projectId,
-          categoryIds: breakdownTask.categoryIds || [],
-          dueDate: subtask.dueDate || breakdownTask.dueDate || null,
-          priority: subtask.priority || breakdownTask.priority || 'medium',
-          energyLevel: subtask.energyLevel || breakdownTask.energyLevel,
-          estimatedMinutes: subtask.estimatedMinutes,
-          tags: subtask.tags || [],
-        };
-      });
+      const preparedSubtasks = subtasks.map((subtask) => ({
+        ...subtask,
+        parentTaskId: breakdownTask.id,
+        projectId: breakdownTask.projectId,
+        categoryIds: breakdownTask.categoryIds || [],
+        dueDate: subtask.dueDate || breakdownTask.dueDate || null,
+        priority: subtask.priority || breakdownTask.priority || 'medium',
+        energyLevel: subtask.energyLevel || breakdownTask.energyLevel,
+        estimatedMinutes: subtask.estimatedMinutes,
+        tags: subtask.tags || [],
+      }));
 
       // @ts-expect-error: preparedSubtasks may not have id, but that's intentional for new tasks
       bulkAddTasks(preparedSubtasks);


### PR DESCRIPTION
## Summary
- keep subtask IDs when adding tasks from AI breakdown

## Testing
- `npm run lint` *(fails: 130 problems - 120 errors, 10 warnings)*