### PR TITLE
Adjust AI task breakdown modal cleanup behavior

### DIFF
--- a/src/components/tasks/AITaskBreakdown.tsx
+++ b/src/components/tasks/AITaskBreakdown.tsx
@@ -565,23 +565,16 @@ Return JSON array only.`
     }
   }, [showContextForm, hasGenerated]);
   
-  // Reset state when component unmounts only
-  React.useEffect(() => {
-    return () => {
-      setHasGenerated(false);
-      setBreakdownOptions([]);
-      setError(null);
-      setContextData({
-        currentState: '',
-        blockers: '',
-        specificGoal: '',
-        environment: ''
-      });
-    };
-  }, []);
+  const handleClose = () => {
+    setError(null);
+    setIsLoading(false);
+    setBreakdownOptions([]);
+    setHasGenerated(false);
+    onClose();
+  };
 
   return (
-    <Modal isOpen={true} onClose={onClose} title="AI Task Breakdown" size="lg">
+    <Modal isOpen={true} onClose={handleClose} title="AI Task Breakdown" size="lg">
       <div className="space-y-4">
         <div className="flex items-center justify-between p-4 bg-purple-50 dark:bg-purple-900/20 rounded-xl">
           <div className="flex items-center">
@@ -905,7 +898,7 @@ Return JSON array only.`
         )}
 
         <div className="flex justify-end space-x-2 pt-4 border-t">
-          <Button variant="secondary" onClick={onClose}>
+          <Button variant="secondary" onClick={handleClose}>
             Cancel
           </Button>
           {!showContextForm && breakdownOptions.length > 0 && (


### PR DESCRIPTION
## Summary
- remove the unmount cleanup that reset AI task breakdown modal state
- handle close actions while the component is mounted so autosaved context persists between openings

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1e11d39648326a5e33c486eabb7ff

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces unmount-based cleanup with a handleClose that resets state on modal close and wires it to Modal and Cancel.
> 
> - **Frontend (src/components/tasks/AITaskBreakdown.tsx)**:
>   - Add `handleClose` to reset `error`, `isLoading`, `breakdownOptions`, `hasGenerated` and call `onClose`; wire to `Modal` `onClose` and the "Cancel" button.
>   - Remove unmount cleanup `useEffect` that previously reset state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c7bf9f52bdc903ad81ffa004c400068c2db2e21f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->