### PR TITLE
Remove AI breakdown modal unmount cleanup

### DIFF
--- a/src/components/tasks/AITaskBreakdown.tsx
+++ b/src/components/tasks/AITaskBreakdown.tsx
@@ -565,20 +565,11 @@ Return JSON array only.`
     }
   }, [showContextForm, hasGenerated]);
   
-  // Reset state when component unmounts only
-  React.useEffect(() => {
-    return () => {
-      setHasGenerated(false);
-      setBreakdownOptions([]);
-      setError(null);
-      setContextData({
-        currentState: '',
-        blockers: '',
-        specificGoal: '',
-        environment: ''
-      });
-    };
-  }, []);
+  const handleCancel = () => {
+    setError(null);
+    setBreakdownOptions([]);
+    onClose();
+  };
 
   return (
     <Modal isOpen={true} onClose={onClose} title="AI Task Breakdown" size="lg">
@@ -905,7 +896,7 @@ Return JSON array only.`
         )}
 
         <div className="flex justify-end space-x-2 pt-4 border-t">
-          <Button variant="secondary" onClick={onClose}>
+          <Button variant="secondary" onClick={handleCancel}>
             Cancel
           </Button>
           {!showContextForm && breakdownOptions.length > 0 && (


### PR DESCRIPTION
## Summary
- remove the unmount cleanup effect from the AI task breakdown modal
- ensure cancel clears transient state without wiping saved context

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1e2c08820832688b37e084729595e