### PR TITLE
Fix SettingsProvider to use local AppContext

### DIFF
--- a/src/components/common/SettingsProvider.tsx
+++ b/src/components/common/SettingsProvider.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { useAppContext } from '../../context/AppContextSupabase';
+import { useAppContext } from '../../context/AppContext';
 
 export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { settings } = useAppContext();


### PR DESCRIPTION
## Summary
- switch SettingsProvider to read settings from the local AppContext instead of the Supabase context so the local-storage build boots correctly

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68e1f6a23e7c8326a46ad1e55dbf7204

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches `SettingsProvider` to read settings from `context/AppContext` instead of `context/AppContextSupabase`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89cd4183c06746079bb5f34cc63ec89780acedfc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->