### PR TITLE
Lazy-load Supabase app when credentials are present

### DIFF
--- a/src/AppWithAuth.tsx
+++ b/src/AppWithAuth.tsx
@@ -1,23 +1,48 @@
 import React, { useState, useEffect } from 'react';
-import AppSupabase from './AppSupabase';
 import App from './App';
 
 function AppWithAuth() {
-  const [useSupabase, setUseSupabase] = useState(true);
+  const [useSupabase, setUseSupabase] = useState(false);
   const [isChecking, setIsChecking] = useState(true);
-  
+  const [SupabaseApp, setSupabaseApp] = useState<React.ComponentType | null>(null);
+
   // Check if we have Supabase credentials
   useEffect(() => {
     const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
     const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
-    
+
     if (!supabaseUrl || !supabaseKey) {
       console.warn('Supabase credentials not found, falling back to localStorage');
       setUseSupabase(false);
+      setIsChecking(false);
+      return;
     }
-    setIsChecking(false);
+
+    let isMounted = true;
+
+    import('./AppSupabase')
+      .then((module) => {
+        if (!isMounted) return;
+        setSupabaseApp(() => module.default);
+        setUseSupabase(true);
+      })
+      .catch((error) => {
+        console.error('Failed to load Supabase app', error);
+        if (isMounted) {
+          setUseSupabase(false);
+        }
+      })
+      .finally(() => {
+        if (isMounted) {
+          setIsChecking(false);
+        }
+      });
+
+    return () => {
+      isMounted = false;
+    };
   }, []);
-  
+
   if (isChecking) {
     return (
       <div className="min-h-screen flex items-center justify-center">
@@ -25,12 +50,12 @@ function AppWithAuth() {
       </div>
     );
   }
-  
+
   // Use Supabase version if credentials are available
-  if (useSupabase) {
-    return <AppSupabase />;
+  if (useSupabase && SupabaseApp) {
+    return <SupabaseApp />;
   }
-  
+
   // Fallback to localStorage version
   return <App />;
 }


### PR DESCRIPTION
## Summary
- load the Supabase-enabled app only after verifying Supabase credentials at runtime
- keep the local-storage app as the default fallback when credentials are missing or loading fails

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1f696d20c832689fafcbdfefa52f8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Dynamically loads the Supabase app only when credentials are present, otherwise defaults to the local-storage app with a guarded initialization flow.
> 
> - **App initialization/auth (`src/AppWithAuth.tsx`)**:
>   - Default to local-storage app (`useSupabase` false) and show "Initializing..." while checking.
>   - Check `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` at runtime; if present, dynamically import `AppSupabase` and render it.
>   - Add `SupabaseApp` state and mount guard to handle async import; fall back to `App` on missing creds or import failure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15ed0a5a68bc901382bb1e64deba49aa002c019f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->