### PR TITLE
Allow overriding AI endpoint from settings

### DIFF
--- a/src/components/tasks/AITaskBreakdown.tsx
+++ b/src/components/tasks/AITaskBreakdown.tsx
@@ -86,8 +86,21 @@ const AITaskBreakdown: React.FC<AITaskBreakdownProps> = ({ task, onAccept, onClo
       const apiKey = localStorage.getItem('ai_api_key');
       const providerName = localStorage.getItem('ai_provider') || 'openai';
       const modelName = localStorage.getItem('ai_model');
+      const customEndpoint = localStorage.getItem('ai_api_endpoint');
       const provider = getProvider(providerName);
       const selectedModel = modelName || provider.defaultModel;
+
+      let requestUrl = provider.baseUrl;
+      const trimmedEndpoint = customEndpoint?.trim();
+
+      if (trimmedEndpoint) {
+        try {
+          const validatedUrl = new URL(trimmedEndpoint);
+          requestUrl = validatedUrl.toString();
+        } catch (e) {
+          console.warn('[AITaskBreakdown] Invalid custom AI endpoint, falling back to provider base URL:', trimmedEndpoint, e);
+        }
+      }
       
       
       if (!apiKey) {
@@ -194,7 +207,7 @@ Return JSON array only.`
           }
         ];
     
-    const response = await fetch(provider.baseUrl, {
+    const response = await fetch(requestUrl, {
       method: 'POST',
       headers: provider.headers(apiKey),
       body: JSON.stringify(provider.formatRequest(messages, selectedModel))


### PR DESCRIPTION
## Summary
- load the saved custom AI endpoint from local storage when generating task breakdowns
- validate and prefer the custom endpoint when building the fetch request URL, falling back to the provider default when invalid

## Testing
- npm run lint *(fails: existing lint issues throughout repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e1f75255948326b8245f5afb7efe02

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Uses a user-defined AI API endpoint from settings (if valid) for task breakdown requests, falling back to the provider base URL when invalid or absent.
> 
> - **AI Task Breakdown (`src/components/tasks/AITaskBreakdown.tsx`)**:
>   - Load `ai_api_endpoint` from `localStorage`, trim and validate as a URL; on invalid, log a warning and fallback.
>   - Derive `requestUrl` (custom or `provider.baseUrl`) and use it in `fetch` for AI requests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9fe907ce5467cba93ae484b8c6377f64a5e93f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->