### PR TITLE
Refactor settings DOM updates into shared helper

### DIFF
--- a/src/components/common/SettingsProvider.tsx
+++ b/src/components/common/SettingsProvider.tsx
@@ -1,68 +1,12 @@
 import React, { useEffect } from 'react';
 import { useAppContext } from '../../context/AppContext';
+import { applySettingsToDocument } from '../../utils/applySettingsToDocument';
 
 export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { settings } = useAppContext();
 
   useEffect(() => {
-    const root = document.documentElement;
-    
-    // Apply font size
-    switch (settings.visual.fontSize) {
-      case 'small':
-        root.style.fontSize = '14px';
-        root.classList.remove('text-base', 'text-lg');
-        root.classList.add('text-sm');
-        break;
-      case 'large':
-        root.style.fontSize = '18px';
-        root.classList.remove('text-sm', 'text-base');
-        root.classList.add('text-lg');
-        break;
-      case 'medium':
-      default:
-        root.style.fontSize = '16px';
-        root.classList.remove('text-sm', 'text-lg');
-        root.classList.add('text-base');
-        break;
-    }
-
-    // Apply layout density
-    switch (settings.visual.layoutDensity) {
-      case 'compact':
-        root.classList.remove('space-comfortable', 'space-spacious');
-        root.classList.add('space-compact');
-        break;
-      case 'spacious':
-        root.classList.remove('space-compact', 'space-comfortable');
-        root.classList.add('space-spacious');
-        break;
-      case 'comfortable':
-      default:
-        root.classList.remove('space-compact', 'space-spacious');
-        root.classList.add('space-comfortable');
-        break;
-    }
-
-    // Apply animations
-    if (settings.visual.reduceAnimations) {
-      root.classList.add('reduce-motion');
-    } else {
-      root.classList.remove('reduce-motion');
-    }
-
-    // Apply high contrast
-    if (settings.visual.highContrast) {
-      root.classList.add('high-contrast');
-    } else {
-      root.classList.remove('high-contrast');
-    }
-
-    // Apply custom priority colors as CSS variables
-    root.style.setProperty('--color-priority-high', settings.visual.customPriorityColors.high);
-    root.style.setProperty('--color-priority-medium', settings.visual.customPriorityColors.medium);
-    root.style.setProperty('--color-priority-low', settings.visual.customPriorityColors.low);
-
+    applySettingsToDocument(settings);
   }, [settings]);
 
   return <>{children}</>;

--- a/src/components/common/SettingsProviderDynamic.tsx
+++ b/src/components/common/SettingsProviderDynamic.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useContext } from 'react';
+import React, { useEffect } from 'react';
 import { AppSettings } from '../../types';
+import { applySettingsToDocument } from '../../utils/applySettingsToDocument';
 
 interface SettingsContext {
   settings: AppSettings;
@@ -7,64 +8,7 @@ interface SettingsContext {
 
 export const SettingsProviderDynamic: React.FC<{ children: React.ReactNode; settings: AppSettings }> = ({ children, settings }) => {
   useEffect(() => {
-    const root = document.documentElement;
-    
-    // Apply font size
-    switch (settings.visual.fontSize) {
-      case 'small':
-        root.style.fontSize = '14px';
-        root.classList.remove('text-base', 'text-lg');
-        root.classList.add('text-sm');
-        break;
-      case 'large':
-        root.style.fontSize = '18px';
-        root.classList.remove('text-sm', 'text-base');
-        root.classList.add('text-lg');
-        break;
-      case 'medium':
-      default:
-        root.style.fontSize = '16px';
-        root.classList.remove('text-sm', 'text-lg');
-        root.classList.add('text-base');
-        break;
-    }
-
-    // Apply layout density
-    switch (settings.visual.layoutDensity) {
-      case 'compact':
-        root.classList.remove('space-comfortable', 'space-spacious');
-        root.classList.add('space-compact');
-        break;
-      case 'spacious':
-        root.classList.remove('space-compact', 'space-comfortable');
-        root.classList.add('space-spacious');
-        break;
-      case 'comfortable':
-      default:
-        root.classList.remove('space-compact', 'space-spacious');
-        root.classList.add('space-comfortable');
-        break;
-    }
-
-    // Apply animations
-    if (settings.visual.reduceAnimations) {
-      root.classList.add('reduce-motion');
-    } else {
-      root.classList.remove('reduce-motion');
-    }
-
-    // Apply high contrast
-    if (settings.visual.highContrast) {
-      root.classList.add('high-contrast');
-    } else {
-      root.classList.remove('high-contrast');
-    }
-
-    // Apply custom priority colors as CSS variables
-    root.style.setProperty('--color-priority-high', settings.visual.customPriorityColors.high);
-    root.style.setProperty('--color-priority-medium', settings.visual.customPriorityColors.medium);
-    root.style.setProperty('--color-priority-low', settings.visual.customPriorityColors.low);
-
+    applySettingsToDocument(settings);
   }, [settings]);
 
   return <>{children}</>;

--- a/src/utils/applySettingsToDocument.ts
+++ b/src/utils/applySettingsToDocument.ts
@@ -1,0 +1,56 @@
+import { AppSettings } from '../types';
+
+export const applySettingsToDocument = (settings: AppSettings) => {
+  const root = document.documentElement;
+
+  switch (settings.visual.fontSize) {
+    case 'small':
+      root.style.fontSize = '14px';
+      root.classList.remove('text-base', 'text-lg');
+      root.classList.add('text-sm');
+      break;
+    case 'large':
+      root.style.fontSize = '18px';
+      root.classList.remove('text-sm', 'text-base');
+      root.classList.add('text-lg');
+      break;
+    case 'medium':
+    default:
+      root.style.fontSize = '16px';
+      root.classList.remove('text-sm', 'text-lg');
+      root.classList.add('text-base');
+      break;
+  }
+
+  switch (settings.visual.layoutDensity) {
+    case 'compact':
+      root.classList.remove('space-comfortable', 'space-spacious');
+      root.classList.add('space-compact');
+      break;
+    case 'spacious':
+      root.classList.remove('space-compact', 'space-comfortable');
+      root.classList.add('space-spacious');
+      break;
+    case 'comfortable':
+    default:
+      root.classList.remove('space-compact', 'space-spacious');
+      root.classList.add('space-comfortable');
+      break;
+  }
+
+  if (settings.visual.reduceAnimations) {
+    root.classList.add('reduce-motion');
+  } else {
+    root.classList.remove('reduce-motion');
+  }
+
+  if (settings.visual.highContrast) {
+    root.classList.add('high-contrast');
+  } else {
+    root.classList.remove('high-contrast');
+  }
+
+  root.style.setProperty('--color-priority-high', settings.visual.customPriorityColors.high);
+  root.style.setProperty('--color-priority-medium', settings.visual.customPriorityColors.medium);
+  root.style.setProperty('--color-priority-low', settings.visual.customPriorityColors.low);
+};


### PR DESCRIPTION
## Summary
- extract document styling logic into a pure `applySettingsToDocument` utility
- reuse the helper from both SettingsProvider variants to keep behavior consistent across builds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5bf0e40188326a842c7c58c2c2e20