### PR TITLE
Add local storage context parity and point local routes to it

### DIFF
--- a/src/components/TaskDisplay.tsx
+++ b/src/components/TaskDisplay.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { CheckCircle2, Circle, Calendar, AlertCircle, ChevronDown, ChevronRight, Folder, PlayCircle, Sparkles, Play, Timer, FolderPlus, Brain } from 'lucide-react';
 import { Task } from '../types';
-import { useAppContext } from '../context/AppContextSupabase';
+import { useAppContext } from '../context/AppContext';
 import { getDueDateStatus, getRelativeTimeDisplay } from '../utils/dateUtils';
 import { GuidedWalkthroughModal } from './tasks/GuidedWalkthroughModal';
 import { QuickDueDateEditor } from './tasks/QuickDueDateEditor';

--- a/src/components/categories/CategoryForm.tsx
+++ b/src/components/categories/CategoryForm.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Category } from '../../types';
-import { useAppContext } from '../../context/AppContextSupabase';
+import { useAppContext } from '../../context/AppContext';
 import Button from '../common/Button';
 
 interface CategoryFormProps {

--- a/src/components/common/CommandPalette.tsx
+++ b/src/components/common/CommandPalette.tsx
@@ -16,7 +16,7 @@ import {
   X
 } from 'lucide-react';
 import { useTheme } from '../../context/ThemeContext';
-import { useAppContext } from '../../context/AppContextSupabase';
+import { useAppContext } from '../../context/AppContext';
 
 interface CommandItem {
   id: string;

--- a/src/components/layout/HeaderWithAuth.tsx
+++ b/src/components/layout/HeaderWithAuth.tsx
@@ -17,7 +17,7 @@ import {
   Sun,
 } from 'lucide-react';
 import { useTheme } from '../../context/ThemeContext';
-import { useAppContext } from '../../context/AppContextSupabase';
+import { useAppContext } from '../../context/AppContext';
 import { DarkModeToggleCompact } from '../common/DarkModeToggle';
 
 const HeaderWithAuth: React.FC = () => {

--- a/src/components/planning/AccountabilityCheckIn.tsx
+++ b/src/components/planning/AccountabilityCheckIn.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { useAppContext } from '../../context/AppContextSupabase';
+import { useAppContext } from '../../context/AppContext';
 import { Task } from '../../types';
 import Card from '../common/Card';
 import Button from '../common/Button';

--- a/src/components/planning/BackwardPlanner.tsx
+++ b/src/components/planning/BackwardPlanner.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Task, Project, Category } from '../../types';
-import { useAppContext } from '../../context/AppContextSupabase';
+import { useAppContext } from '../../context/AppContext';
 import Button from '../common/Button';
 import { Calendar, Flag, ArrowDownCircle, Save, Plus, Target } from 'lucide-react';
 import { formatDate } from '../../utils/helpers';

--- a/src/components/planning/TaskPlanningBoard.tsx
+++ b/src/components/planning/TaskPlanningBoard.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Task, Project, Category } from '../../types';
 import { ImprovedTaskCard } from '../tasks/ImprovedTaskCard';
-import { useAppContext } from '../../context/AppContextSupabase';
+import { useAppContext } from '../../context/AppContext';
 import { Clock, Target, Menu, Download, LayoutGrid, List, ArrowLeft, ArrowRight, Plus } from 'lucide-react';
 import Button from '../common/Button';
 import QuickTaskInput from '../tasks/QuickTaskInput';

--- a/src/components/planning/WeeklyReviewSystem.tsx
+++ b/src/components/planning/WeeklyReviewSystem.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useAppContext } from '../../context/AppContextSupabase';
+import { useAppContext } from '../../context/AppContext';
 import { Task, Project } from '../../types';
 import Card from '../common/Card';
 import Button from '../common/Button';

--- a/src/components/planning/calendar/CalendarView.tsx
+++ b/src/components/planning/calendar/CalendarView.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Task } from '../../../types';
-import { useAppContext } from '../../../context/AppContextSupabase';
+import { useAppContext } from '../../../context/AppContext';
 import { 
   ChevronLeft, 
   ChevronRight, 

--- a/src/components/planning/calendar/WorkScheduleSelector.tsx
+++ b/src/components/planning/calendar/WorkScheduleSelector.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useAppContext } from '../../../context/AppContextSupabase';
+import { useAppContext } from '../../../context/AppContext';
 import { WorkShift, ShiftType, DEFAULT_SHIFTS } from '../../../types/WorkSchedule';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 

--- a/src/components/planning/daily-planner/DailyPlannerGrid.tsx
+++ b/src/components/planning/daily-planner/DailyPlannerGrid.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { DndContext, DragEndEvent, DragOverlay, useSensor, useSensors, PointerSensor, DragStartEvent } from '@dnd-kit/core';
 import { Task, TimeBlock } from '../../../types';
-import { useAppContext } from '../../../context/AppContextSupabase';
+import { useAppContext } from '../../../context/AppContext';
 import { Plus, Clock, Edit, Info } from 'lucide-react';
 import Button from '../../common/Button';
 import { TaskDisplay } from '../../TaskDisplay';

--- a/src/components/planning/project-breakdown/SimplifiedProjectBreakdown.tsx
+++ b/src/components/planning/project-breakdown/SimplifiedProjectBreakdown.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Task, Project, Category } from '../../../types';
-import { useAppContext } from '../../../context/AppContextSupabase';
+import { useAppContext } from '../../../context/AppContext';
 import Button from '../../common/Button';
 import { ChevronDown, ChevronRight, Save, Plus, Target, Clock, Trash2 } from 'lucide-react';
 import { generateId } from '../../../utils/helpers';

--- a/src/components/planning/weekly-review/WeeklyReviewSystemFixed.tsx
+++ b/src/components/planning/weekly-review/WeeklyReviewSystemFixed.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useAppContext } from '../../../context/AppContextSupabase';
+import { useAppContext } from '../../../context/AppContext';
 import { Task } from '../../../types';
 import Card from '../../common/Card';
 import Button from '../../common/Button';

--- a/src/components/projects/ProjectForm.tsx
+++ b/src/components/projects/ProjectForm.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Project } from '../../types';
-import { useAppContext } from '../../context/AppContextSupabase';
+import { useAppContext } from '../../context/AppContext';
 import Button from '../common/Button';
 
 interface ProjectFormProps {

--- a/src/components/settings/DataMigration.tsx
+++ b/src/components/settings/DataMigration.tsx
@@ -4,7 +4,7 @@ import Button from '../common/Button';
 import Card from '../common/Card';
 import * as localStorage from '../../utils/localStorage';
 import { DatabaseService } from '../../services/database';
-import { useAppContext } from '../../context/AppContextSupabase';
+import { useAppContext } from '../../context/AppContext';
 import { DailyPlan } from '../../types';
 import { v4 as uuidv4 } from 'uuid';
 import { supabase } from '../../lib/supabase';

--- a/src/components/settings/DuplicateCleanup.tsx
+++ b/src/components/settings/DuplicateCleanup.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Trash2, AlertCircle, CheckCircle, XCircle, Loader2, Users, Tag } from 'lucide-react';
 import Button from '../common/Button';
 import Card from '../common/Card';
-import { useAppContext } from '../../context/AppContextSupabase';
+import { useAppContext } from '../../context/AppContext';
 import { Task, Project, Category } from '../../types';
 
 interface DuplicateTaskGroup {

--- a/src/components/tasks/BrainDumpPrompt.tsx
+++ b/src/components/tasks/BrainDumpPrompt.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useAppContext } from '../../context/AppContextSupabase';
+import { useAppContext } from '../../context/AppContext';
 import Card from '../common/Card';
 import Button from '../common/Button';
 import { ArrowRight, BrainCircuit, Plus, RefreshCw } from 'lucide-react';

--- a/src/components/tasks/FuzzyTaskBreakdown.tsx
+++ b/src/components/tasks/FuzzyTaskBreakdown.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { X, ArrowRight, ArrowLeft, Sparkles, CheckCircle, AlertCircle, Users, Calendar, Brain, Search, MessageSquare, ClipboardList, ChevronRight, Loader2 } from 'lucide-react';
 import { Task, Category } from '../../types';
-import { useAppContext } from '../../context/AppContextSupabase';
+import { useAppContext } from '../../context/AppContext';
 import Button from '../common/Button';
 import { AI_PROVIDERS, getProvider } from '../../utils/aiProviders';
 

--- a/src/components/tasks/GuidedTaskWalkthrough.tsx
+++ b/src/components/tasks/GuidedTaskWalkthrough.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { Task } from '../../types';
-import { useAppContext } from '../../context/AppContextSupabase';
+import { useAppContext } from '../../context/AppContext';
 import Card from '../common/Card';
 import Button from '../common/Button';
 import Badge from '../common/Badge';

--- a/src/components/tasks/HierarchicalTaskView.tsx
+++ b/src/components/tasks/HierarchicalTaskView.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Task, Project, Category } from '../../types';
 import { ChevronDown, ChevronRight, Plus, Circle, CheckCircle2, Calendar } from 'lucide-react';
 import Badge from '../common/Badge';
-import { useAppContext } from '../../context/AppContextSupabase';
+import { useAppContext } from '../../context/AppContext';
 import { formatDateForDisplay } from '../../utils/helpers';
 
 interface HierarchicalTaskViewProps {

--- a/src/components/tasks/ImprovedTaskCard.tsx
+++ b/src/components/tasks/ImprovedTaskCard.tsx
@@ -25,7 +25,7 @@ import { Task, Project, Category } from '../../types';
 import Badge from '../common/Badge';
 import { formatDateForDisplay } from '../../utils/helpers';
 import { getRelativeTimeDisplay } from '../../utils/dateUtils';
-import { useAppContext } from '../../context/AppContextSupabase';
+import { useAppContext } from '../../context/AppContext';
 import { QuickDueDateEditor } from './QuickDueDateEditor';
 import { getUrgencyEmoji, getEmotionalWeightEmoji, getEnergyRequiredEmoji, calculateSmartPriorityScore } from '../../utils/taskPrioritization';
 import { TimeSpentModal } from './TimeSpentModal';

--- a/src/components/tasks/MobileTaskCard.tsx
+++ b/src/components/tasks/MobileTaskCard.tsx
@@ -4,7 +4,7 @@ import { Task } from '../../types';
 import { useSwipeGesture } from '../../hooks/useSwipeGesture';
 import { formatDistanceToNow } from 'date-fns';
 import { FuzzyTaskBreakdownSimple } from './FuzzyTaskBreakdownSimple';
-import { useAppContext } from '../../context/AppContextSupabase';
+import { useAppContext } from '../../context/AppContext';
 
 interface MobileTaskCardProps {
   task: Task;

--- a/src/components/tasks/QuickCapture.tsx
+++ b/src/components/tasks/QuickCapture.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { useAppContext } from '../../context/AppContextSupabase';
+import { useAppContext } from '../../context/AppContext';
 import { Plus, Circle } from 'lucide-react';
 import { extractDateFromText, formatDateString } from '../../utils/dateUtils';
 

--- a/src/components/tasks/QuickTaskInput.tsx
+++ b/src/components/tasks/QuickTaskInput.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { Task } from '../../types';
-import { useAppContext } from '../../context/AppContextSupabase';
+import { useAppContext } from '../../context/AppContext';
 import { Plus, Circle, Calendar, Folder, Tag, Flame, Star, Brain, Battery } from 'lucide-react';
 import { getTodayString, getTomorrowString, formatDateString, extractDateFromText } from '../../utils/dateUtils';
 

--- a/src/components/tasks/SubtaskList.tsx
+++ b/src/components/tasks/SubtaskList.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Task } from '../../types';
-import { useAppContext } from '../../context/AppContextSupabase';
+import { useAppContext } from '../../context/AppContext';
 import { Plus, X, ChevronDown, ChevronRight, Clock } from 'lucide-react';
 import Button from '../common/Button';
 

--- a/src/components/tasks/TaskDetailWizard.tsx
+++ b/src/components/tasks/TaskDetailWizard.tsx
@@ -18,7 +18,7 @@ import {
   Timer
 } from 'lucide-react';
 import { Task, Project, Category } from '../../types';
-import { useAppContext } from '../../context/AppContextSupabase';
+import { useAppContext } from '../../context/AppContext';
 import { format, addDays, startOfToday } from 'date-fns';
 
 interface TaskDetailWizardProps {

--- a/src/components/tasks/TaskForm.tsx
+++ b/src/components/tasks/TaskForm.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { Task, Project, Category } from '../../types';
-import { useAppContext } from '../../context/AppContextSupabase';
+import { useAppContext } from '../../context/AppContext';
 import { useTaskAutoSave } from '../../hooks/useTaskAutoSave';
 import Button from '../common/Button';
 import Modal from '../common/Modal';

--- a/src/components/tasks/TaskFormWithDependencies.tsx
+++ b/src/components/tasks/TaskFormWithDependencies.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Task } from '../../types';
-import { useAppContext } from '../../context/AppContextSupabase';
+import { useAppContext } from '../../context/AppContext';
 import Modal from '../common/Modal';
 import Button from '../common/Button';
 import SubtaskList from './SubtaskList';

--- a/src/components/tasks/TaskFormWithDependencies_broken.tsx
+++ b/src/components/tasks/TaskFormWithDependencies_broken.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Task } from '../../types';
-import { useAppContext } from '../../context/AppContextSupabase';
+import { useAppContext } from '../../context/AppContext';
 import Modal from '../common/Modal';
 import Button from '../common/Button';
 import SubtaskList from './SubtaskList';

--- a/src/components/whatnow/WhatNowWizard.tsx
+++ b/src/components/whatnow/WhatNowWizard.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Task, WhatNowCriteria } from '../../types';
-import { useAppContext } from '../../context/AppContextSupabase';
+import { useAppContext } from '../../context/AppContext';
 import { sortTasks, EnergyLevel, getTaskRecommendationReason } from '../../utils/taskPrioritization';
 import Card from '../common/Card';
 import Button from '../common/Button';

--- a/src/context/AppContextSupabase.tsx
+++ b/src/context/AppContextSupabase.tsx
@@ -6,13 +6,14 @@ import { generateId, recommendTasks as recommendTasksUtil } from '../utils/helpe
 import { getTodayString, formatDateString, extractDateFromText } from '../utils/dateUtils';
 import { supabase } from '../lib/supabase';
 import { User } from '@supabase/supabase-js';
+import { AppContext as LocalAppContext, AppContextType as LocalAppContextType } from './AppContext';
 
 interface DeletedTask {
   task: Task;
   timestamp: number;
 }
 
-interface AppContextType {
+interface SupabaseAppContextType {
   // Auth
   user: User | null;
   signOut: () => Promise<void>;
@@ -114,7 +115,7 @@ interface AppContextType {
   isDataInitialized: boolean;
 }
 
-const AppContext = createContext<AppContextType | undefined>(undefined);
+const SupabaseAppContext = createContext<SupabaseAppContextType | undefined>(undefined);
 
 const UNDO_WINDOW = 5000; // 5 seconds window for undo
 
@@ -1717,7 +1718,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
     // TODO: Implement sample data initialization
   }, [user]);
 
-  const contextValue: AppContextType = {
+  const contextValue: SupabaseAppContextType = {
     user,
     signOut,
     
@@ -1805,14 +1806,16 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
   };
 
   return (
-    <AppContext.Provider value={contextValue}>
-      {children}
-    </AppContext.Provider>
+    <LocalAppContext.Provider value={contextValue as unknown as LocalAppContextType}>
+      <SupabaseAppContext.Provider value={contextValue}>
+        {children}
+      </SupabaseAppContext.Provider>
+    </LocalAppContext.Provider>
   );
 };
 
-export const useAppContext = (): AppContextType => {
-  const context = React.useContext(AppContext);
+export const useAppContext = (): SupabaseAppContextType => {
+  const context = React.useContext(SupabaseAppContext);
   if (context === undefined) {
     throw new Error('useAppContext must be used within an AppProvider');
   }

--- a/src/hooks/useTaskAutoSave.ts
+++ b/src/hooks/useTaskAutoSave.ts
@@ -1,5 +1,5 @@
 import { useCallback, useRef } from 'react';
-import { useAppContext } from '../context/AppContextSupabase';
+import { useAppContext } from '../context/AppContext';
 import { Task } from '../types';
 import { useAutoSave } from './useAutoSave';
 

--- a/src/pages/CategoriesPage.tsx
+++ b/src/pages/CategoriesPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo } from 'react';
-import { useAppContext } from '../context/AppContextSupabase';
+import { useAppContext } from '../context/AppContext';
 import { Category, Task } from '../types';
 import CategoryCard from '../components/categories/CategoryCard';
 import CategoryForm from '../components/categories/CategoryForm';

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -16,7 +16,7 @@ import {
   TrendingUp,
   Compass
 } from 'lucide-react';
-import { useAppContext } from '../context/AppContextSupabase';
+import { useAppContext } from '../context/AppContext';
 import Card from '../components/common/Card';
 import Button from '../components/common/Button';
 import { TaskDisplay } from '../components/TaskDisplay';

--- a/src/pages/DeletedTasksPage.tsx
+++ b/src/pages/DeletedTasksPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useAppContext } from '../context/AppContextSupabase';
+import { useAppContext } from '../context/AppContext';
 import { DeletedTask, getDeletedTasks, restoreDeletedTask, permanentlyDeleteTask, clearAllDeletedTasks } from '../utils/localStorage';
 import Card from '../components/common/Card';
 import Button from '../components/common/Button';

--- a/src/pages/EnhancedPlanningPage.tsx
+++ b/src/pages/EnhancedPlanningPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useAppContext } from '../context/AppContextSupabase';
+import { useAppContext } from '../context/AppContext';
 import { Task, Project } from '../types';
 import { Backpack, Calendar, Target, Cpu, Menu, Clock, Plus } from 'lucide-react';
 import Button from '../components/common/Button';

--- a/src/pages/PlannerPage.tsx
+++ b/src/pages/PlannerPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useAppContext } from '../context/AppContextSupabase';
+import { useAppContext } from '../context/AppContext';
 import DailyPlannerGrid from '../components/planning/daily-planner/DailyPlannerGrid';
 import { formatDateForDisplay } from '../utils/helpers';
 import { ChevronLeft, ChevronRight, Clock, Calendar, ExternalLink } from 'lucide-react';

--- a/src/pages/ProjectDetailPage.tsx
+++ b/src/pages/ProjectDetailPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useParams, Link, Navigate, useNavigate } from 'react-router-dom';
-import { useAppContext } from '../context/AppContextSupabase';
+import { useAppContext } from '../context/AppContext';
 import { Task } from '../types';
 import { TaskDisplay } from "../components/TaskDisplay";
 import TaskForm from '../components/tasks/TaskForm';

--- a/src/pages/ProjectsPage.tsx
+++ b/src/pages/ProjectsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo } from 'react';
-import { useAppContext } from '../context/AppContextSupabase';
+import { useAppContext } from '../context/AppContext';
 import { Project, Task } from '../types';
 import ProjectCard from '../components/projects/ProjectCard';
 import ProjectForm from '../components/projects/ProjectForm';

--- a/src/pages/TasksPageWithBulkOps.tsx
+++ b/src/pages/TasksPageWithBulkOps.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
-import { useAppContext } from '../context/AppContextSupabase';
+import { useAppContext } from '../context/AppContext';
 import { Task, TaskSortMode, WhatNowCriteria } from '../types';
 import { TaskDisplay } from '../components/TaskDisplay';
 import TaskFormWithDependencies from '../components/tasks/TaskFormWithDependencies';


### PR DESCRIPTION
## Summary
- expand the local AppContext to mirror the Supabase API with async helpers, bulk actions, and undo support
- wrap the Supabase provider with the local context so shared components can resolve useAppContext from the local module
- update local routes, shared task/project components, and hooks to import the local context instead of the Supabase variant

## Testing
- npm run build
- npm run dev -- --host 0.0.0.0 --port 4173 (manual smoke test of /, /#/tasks, /#/projects)


------
https://chatgpt.com/codex/tasks/task_e_68e5d19d3730832682ed8f11dc2fb75f

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expand local `AppContext` to Supabase-parity (async, bulk ops, undo, dependencies) and update app to import/use it, while wrapping Supabase provider with the local context.
> 
> - **Context layer**:
>   - Expand `src/context/AppContext.tsx` to Supabase-parity: async CRUD, bulk ops (`bulkAdd/Delete/Complete/Move/Archive/AssignCategories/ConvertToSubtasks`), dependencies (`add/remove/get`), archive helpers, project ops (`complete/archive/reorder`), work schedule/journal/settings async, undo-delete stack with timeout, and `setTasks` helper.
>   - Add auth parity fields (`user: null`, `signOut`) and internal persistence helpers; introduce UNDO timer.
> - **Supabase provider integration**:
>   - In `src/context/AppContextSupabase.tsx`, create `SupabaseAppContext`, keep Supabase features, and wrap children with `LocalAppContext.Provider` so shared `useAppContext` calls resolve locally; adjust types/exports accordingly.
> - **App-wide import switch**:
>   - Replace `useAppContext` imports from `AppContextSupabase` to `AppContext` across components/pages/hooks (tasks, planning, settings, calendar, dashboards, etc.).
> - **Utilities/hooks**:
>   - Update `hooks/useTaskAutoSave` to use local context.
> - **Pages/components tweaks**:
>   - Minor adjustments to use new async API and helpers (e.g., `DeletedTasksPage` uses `setTasks`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e33dd12e7c40e0709e6242d0475d90d5aa9eb419. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->